### PR TITLE
Reducing the footprint of the Vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,8 +23,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.name = "ideal-local.inventid.net"
   end
 
-  memory = userConfig["memory"] || 2048
-  cpus = userConfig["cpus"] || 2
+  memory = userConfig["memory"] || 1024
+  cpus = userConfig["cpus"] || 1
 
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", memory, "--cpus", cpus]


### PR DESCRIPTION
2GB RAM and 2 cores was a little bit much, so reducing that.

No performance impact, except on provisioning
